### PR TITLE
Fixed the bug with character set

### DIFF
--- a/Magentron/EmailImages/Model/Email/Template.php
+++ b/Magentron/EmailImages/Model/Email/Template.php
@@ -20,7 +20,7 @@ class Magentron_EmailImages_Model_Email_Template extends Mage_Core_Model_Email_T
 	public function getMail()
 	{
         if (is_null($this->_mail)) {
-            $this->_mail = Mage::getModel('emailimages/mail', array('utf-8'));
+            $this->_mail = Mage::getModel('emailimages/mail', 'utf-8');
         }
         return $this->_mail;
 	}

--- a/Magentron/EmailImages/Model/Newsletter/Template.php
+++ b/Magentron/EmailImages/Model/Newsletter/Template.php
@@ -20,7 +20,7 @@ class Magentron_EmailImages_Model_Newsletter_Template extends Mage_Newsletter_Mo
 	public function getMail()
 	{
         if (is_null($this->_mail)) {
-            $this->_mail = Mage::getModel('emailimages/mail', array('utf-8'));
+            $this->_mail = Mage::getModel('emailimages/mail', 'utf-8');
         }
         return $this->_mail;
 	}


### PR DESCRIPTION
An array has been passed to the Zend_Mail::__construct method causing the email header to look like this: Content-Type: text/html; charset=Array
